### PR TITLE
Allow reading request body before sending response headers

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -227,7 +227,7 @@ pub struct ConnectRequest {
     pub request_type: ConnectionType,
     pub metadata: HashMap<String, String>,
     send_stream: QuinnSendStream,
-    recv_stream: QuinnRecvStream,
+    pub recv_stream: QuinnRecvStream,
 }
 
 impl ConnectRequest {


### PR DESCRIPTION
When handing a request with data (eg: POST) it's often necessary to read the body of the request before determining the appropriate HTTP status code for the response.

Make `ConnectRequest.recv_stream` public so it can be read before calling `ConnectRequest.respond_with()`.

(`send_stream` is left private so `respond_with()` can ensure it sends the response's headers before the response body.)

Thanks for making this library/crate!